### PR TITLE
feat: redirect if user is not logged in

### DIFF
--- a/src/pages/user/[id]/index.tsx
+++ b/src/pages/user/[id]/index.tsx
@@ -1,8 +1,11 @@
+import type { GetServerSidePropsContext } from "next";
 import { type NextPage } from "next";
+import { getServerSession } from "next-auth";
 import { useSession } from "next-auth/react";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { Header } from "~/components/ui/Header";
+import { authOptions } from "~/server/auth";
 import { api } from "~/utils/api";
 
 const Settings: NextPage = () => {
@@ -36,3 +39,20 @@ const Settings: NextPage = () => {
 };
 
 export default Settings;
+
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const session = await getServerSession(context.req, context.res, authOptions);
+
+  if (!session) {
+    return {
+      redirect: {
+        destination: "/login",
+        permanent: false,
+      },
+    };
+  }
+
+  return {
+    props: { session },
+  };
+}


### PR DESCRIPTION
# Overview
This PR sets up a redirect on the user/:id page for when there is no user that is logged in. The video below shows the sad path where the user is not logged in!

I am unable to demo the happy path for when they are logged in due to an invalid Google Client ID for the moment!


# Screenshot

https://github.com/alexisintech/jaxanimals/assets/43508242/25cbb238-1dee-465d-9dbc-b0dcc378608d

