### PR TITLE
fix/(issue 28): solved hydration error caused by next-themes mismatching client vs. server trees

### DIFF
--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useEffect, useState } from "react";
 import { BsMoonStarsFill } from "react-icons/bs";
 import { FiSun } from "react-icons/fi";
 import { useTheme } from "next-themes";
@@ -22,10 +22,20 @@ import { useRouter } from "next/router";
 import { cn } from "~/utils/cn";
 
 const Header = ({ loggingIn }: HeaderProps) => {
+  const [mounted, setMounted] = useState(false);
   const { theme, setTheme } = useTheme();
   const { data: sessionData } = useSession();
   const { push, asPath } = useRouter();
   const user = sessionData?.user;
+
+  // fixing a hydration error for next-themes
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
 
   const handleLogin = () => push(`/login?callbackUrl=${asPath}`);
 


### PR DESCRIPTION
solution found in next-themes docs: https://github.com/pacocoursey/next-themes#avoid-hydration-mismatch#28 

closes #28 